### PR TITLE
Add coverage map utilities and schema

### DIFF
--- a/crates/veri-core/src/coverage.rs
+++ b/crates/veri-core/src/coverage.rs
@@ -1,0 +1,142 @@
+use std::collections::{BTreeSet, HashMap};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Coverage information for a single file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileCoverage {
+    /// Digest of the file contents used to invalidate stale coverage.
+    pub digest: String,
+    /// Set of covered line numbers.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub lines: BTreeSet<u32>,
+}
+
+/// Mapping from file paths to coverage information.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(transparent)]
+pub struct CoverageMap(pub HashMap<String, FileCoverage>);
+
+impl CoverageMap {
+    /// Create an empty coverage map.
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    /// Merge another coverage map into this one.
+    ///
+    /// If a file's digest has changed, the existing coverage is replaced.
+    pub fn merge(&mut self, other: &CoverageMap) {
+        for (path, new_cov) in &other.0 {
+            let entry = self
+                .0
+                .entry(path.clone())
+                .or_insert_with(|| FileCoverage {
+                    digest: new_cov.digest.clone(),
+                    lines: BTreeSet::new(),
+                });
+
+            if entry.digest != new_cov.digest {
+                // File changed, replace coverage.
+                entry.digest = new_cov.digest.clone();
+                entry.lines.clear();
+            }
+
+            entry.lines.extend(&new_cov.lines);
+        }
+    }
+
+    /// Load a coverage map from a JSON file.
+    pub fn load(path: &Path) -> Result<Self> {
+        let data = std::fs::read_to_string(path).context("failed to read coverage map")?;
+        let map: CoverageMap = serde_json::from_str(&data).context("invalid coverage map json")?;
+        Ok(map)
+    }
+
+    /// Save a coverage map to a JSON file.
+    pub fn save(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context("failed to create coverage map directory")?;
+        }
+        let data = serde_json::to_string_pretty(self).context("failed to serialize coverage map")?;
+        std::fs::write(path, data).context("failed to write coverage map")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fc(digest: &str, lines: &[u32]) -> FileCoverage {
+        FileCoverage {
+            digest: digest.to_string(),
+            lines: lines.iter().copied().collect(),
+        }
+    }
+
+    #[test]
+    fn merge_idempotent() {
+        let mut base = CoverageMap(HashMap::from([(
+            "file.py".to_string(),
+            fc("d1", &[1, 2]),
+        )]));
+        let delta = CoverageMap(HashMap::from([(
+            "file.py".to_string(),
+            fc("d1", &[2, 3]),
+        )]));
+
+        let mut merged_once = base.clone();
+        merged_once.merge(&delta);
+
+        let mut merged_twice = merged_once.clone();
+        merged_twice.merge(&delta);
+
+        assert_eq!(merged_once, merged_twice);
+    }
+
+    #[test]
+    fn merge_associative() {
+        let a = CoverageMap(HashMap::from([(
+            "f.py".to_string(),
+            fc("d", &[1]),
+        )]));
+        let b = CoverageMap(HashMap::from([(
+            "f.py".to_string(),
+            fc("d", &[2]),
+        )]));
+        let c = CoverageMap(HashMap::from([(
+            "f.py".to_string(),
+            fc("d", &[3]),
+        )]));
+
+        let mut left = a.clone();
+        left.merge(&b);
+        left.merge(&c);
+
+        let mut right = a.clone();
+        let mut bc = b.clone();
+        bc.merge(&c);
+        right.merge(&bc);
+
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn digest_change_replaces_coverage() {
+        let mut base = CoverageMap(HashMap::from([(
+            "file.py".to_string(),
+            fc("d1", &[1, 2]),
+        )]));
+        let delta = CoverageMap(HashMap::from([(
+            "file.py".to_string(),
+            fc("d2", &[5]),
+        )]));
+
+        base.merge(&delta);
+        assert_eq!(base.0["file.py"].digest, "d2");
+        assert_eq!(base.0["file.py"].lines, BTreeSet::from([5]));
+    }
+}

--- a/crates/veri-core/src/lib.rs
+++ b/crates/veri-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod import_graph;
 pub mod planner;
 pub mod scheduler;
 pub mod worker_pool;
+pub mod coverage;
 
 #[cfg(test)]
 mod schema_tests;

--- a/crates/veri-core/src/scheduler.rs
+++ b/crates/veri-core/src/scheduler.rs
@@ -453,6 +453,10 @@ mod tests {
         let config = SchedulerConfig::default();
         let scheduler = TestScheduler::new(config);
         let tests_index = TestsIndex {
+            version: "1.0.0".to_string(),
+            generated_at: "2023-01-01T00:00:00Z".to_string(),
+            python_version: "3.9.0".to_string(),
+            pytest_version: "7.0.0".to_string(),
             tests: Vec::new(),
             collection_errors: Vec::new(),
         };

--- a/crates/veri-core/src/schema_tests.rs
+++ b/crates/veri-core/src/schema_tests.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    // Placeholder for future schema validation tests
+    #[test]
+    fn placeholder() {
+        assert!(true);
+    }
+}

--- a/schemas/coverage.map.json
+++ b/schemas/coverage.map.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://veri.dev/schemas/coverage.map.json",
+    "title": "Coverage Map",
+    "description": "Per-file coverage data with file digests and covered lines",
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$",
+            "description": "Schema version"
+        },
+        "generated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when this map was generated"
+        },
+        "files": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/file_coverage"
+            },
+            "description": "Mapping of file paths to coverage information"
+        }
+    },
+    "required": ["version", "generated_at", "files"],
+    "additionalProperties": false,
+    "$defs": {
+        "file_coverage": {
+            "type": "object",
+            "properties": {
+                "digest": {
+                    "type": "string",
+                    "description": "Hash of file contents"
+                },
+                "lines": {
+                    "type": "array",
+                    "items": {"type": "integer", "minimum": 1},
+                    "description": "Covered line numbers"
+                }
+            },
+            "required": ["digest", "lines"],
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CoverageMap` structure with merge/load/save logic and tests
- define JSON schema for `coverage.map` artifact
- fix scheduler test initialization for `TestsIndex`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b22ace425c8333813df7ecb6038651