### PR TITLE
Add functional tests across components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -302,6 +319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +344,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "env_logger"
@@ -884,6 +913,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,6 +1291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1399,7 @@ name = "veri-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
  "ctrlc",
@@ -1345,6 +1408,7 @@ dependencies = [
  "num_cpus",
  "serde",
  "serde_json",
+ "tempdir",
  "toml",
  "veri-core",
 ]
@@ -1378,6 +1442,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/veri-cli/Cargo.toml
+++ b/crates/veri-cli/Cargo.toml
@@ -15,3 +15,7 @@ log = "0.4"
 num_cpus = "1.0"
 ctrlc = "3.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempdir = "0.3"

--- a/crates/veri-cli/src/cli_tests.rs
+++ b/crates/veri-cli/src/cli_tests.rs
@@ -1,7 +1,12 @@
 #[cfg(test)]
 mod tests {
     use crate::cli::{Cli, Commands, Engine, ExitCode};
+    use assert_cmd::Command;
     use clap::Parser;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command as StdCommand;
+    use tempdir::TempDir;
 
     #[test]
     fn test_cli_help_contains_all_flags() {
@@ -97,5 +102,29 @@ mod tests {
 
         let args = Cli::parse_from(["veri", "--quiet"]);
         assert!(args.quiet);
+    }
+
+    #[test]
+    fn runs_collect_command() {
+        let temp = TempDir::new("veri_cli").unwrap();
+        fs::write(
+            temp.path().join("test_sample.py"),
+            "def test_ok():\n    assert 1 == 1\n",
+        )
+        .unwrap();
+
+        StdCommand::new("cargo")
+            .arg("build")
+            .arg("-p")
+            .arg("veri-cli")
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .status()
+            .unwrap();
+
+        let binary = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/veri-cli");
+        let mut cmd = Command::new(binary);
+        cmd.current_dir(temp.path()).arg("--all").assert().success();
+
+        assert!(temp.path().join(".veri/cache/tests.index.json").exists());
     }
 }

--- a/crates/veri-cli/src/main.rs
+++ b/crates/veri-cli/src/main.rs
@@ -443,11 +443,7 @@ fn run_veri_engine(
     // Fallback: if nothing selected but tests exist, run all tests
     if nodeids_to_run.is_empty() && !tests_index.tests.is_empty() {
         println!("ℹ️  No impacted tests detected; defaulting to run all tests");
-        nodeids_to_run = tests_index
-            .tests
-            .iter()
-            .map(|t| t.nodeid.clone())
-            .collect();
+        nodeids_to_run = tests_index.tests.iter().map(|t| t.nodeid.clone()).collect();
     }
 
     if nodeids_to_run.is_empty() {
@@ -940,6 +936,7 @@ fn parse_worker_count(workers: &Option<String>) -> Result<usize> {
 }
 
 /// Execute tests in parallel using scheduler and worker pool
+#[allow(clippy::too_many_arguments)]
 fn execute_tests_parallel(
     nodeids: &[String],
     tests_index: &veri_core::python_worker::TestsIndex,
@@ -1083,8 +1080,10 @@ fn execute_tests_parallel(
         // Update aggregated_timings incrementally
         for r in &results {
             for t in &r.per_test {
-                let entry = timings.aggregated_timings.entry(t.nodeid.clone()).or_insert(
-                    veri_core::schemas::AggregatedTiming {
+                let entry = timings
+                    .aggregated_timings
+                    .entry(t.nodeid.clone())
+                    .or_insert(veri_core::schemas::AggregatedTiming {
                         nodeid: t.nodeid.clone(),
                         run_count: 0,
                         avg_duration: 0.0,
@@ -1094,8 +1093,7 @@ fn execute_tests_parallel(
                         p95_duration: 0.0,
                         last_duration: 0.0,
                         stability: 1.0,
-                    },
-                );
+                    });
                 let d = (t.duration_ms as f64) / 1000.0;
                 entry.run_count += 1;
                 // Incremental average

--- a/crates/veri-core/src/coverage.rs
+++ b/crates/veri-core/src/coverage.rs
@@ -329,11 +329,22 @@ impl CoverageCollector {
                 if !combine_ok {
                     // Fallback to system coverage if uv unavailable
                     let _ = Command::new("python")
-                        .args(["-m", "coverage", "combine", &self.cache_dir.to_string_lossy()])
+                        .args([
+                            "-m",
+                            "coverage",
+                            "combine",
+                            &self.cache_dir.to_string_lossy(),
+                        ])
                         .current_dir(&self.work_dir)
                         .status();
                     let _ = Command::new("python")
-                        .args(["-m", "coverage", "json", "-o", &coverage_json.to_string_lossy()])
+                        .args([
+                            "-m",
+                            "coverage",
+                            "json",
+                            "-o",
+                            &coverage_json.to_string_lossy(),
+                        ])
                         .current_dir(&self.work_dir)
                         .status();
                 }
@@ -364,7 +375,11 @@ impl CoverageCollector {
         }
         // Try crate-relative ../../py_worker
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        if let Some(c) = manifest_dir.parent().and_then(|p| p.parent()).map(|p| p.join("py_worker")) {
+        if let Some(c) = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("py_worker"))
+        {
             if c.exists() {
                 return Some(c);
             }

--- a/crates/veri-core/src/import_graph.rs
+++ b/crates/veri-core/src/import_graph.rs
@@ -530,3 +530,42 @@ impl Default for ModuleMap {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn builds_simple_import_graph() {
+        let work_dir = TempDir::new().expect("work dir");
+        let cache_dir = TempDir::new().expect("cache dir");
+
+        fs::write(work_dir.path().join("a.py"), "import b\n").unwrap();
+        fs::write(work_dir.path().join("b.py"), "def foo():\n    return 42\n").unwrap();
+
+        let py_worker = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../py_worker")
+            .canonicalize()
+            .unwrap();
+        let existing = env::var("PYTHONPATH").unwrap_or_default();
+        let new_path = if existing.is_empty() {
+            py_worker.to_string_lossy().to_string()
+        } else {
+            format!("{}:{}", py_worker.display(), existing)
+        };
+        env::set_var("PYTHONPATH", new_path);
+
+        let mut builder = ImportGraphBuilder::new(work_dir.path(), cache_dir.path());
+        let (imports_graph, _, _) = builder.build_graphs().expect("build graphs");
+
+        assert_eq!(imports_graph.edges.len(), 1);
+        let edge = &imports_graph.edges[0];
+        assert_eq!(edge.from_module, "a");
+        assert_eq!(edge.to_module, "b");
+        assert!(matches!(edge.import_type, ImportType::Import));
+    }
+}

--- a/crates/veri-core/src/planner.rs
+++ b/crates/veri-core/src/planner.rs
@@ -493,3 +493,84 @@ impl TestPlanner {
         output.join("\n")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::python_worker::TestNode;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn selects_changed_test_file() {
+        let work_dir = TempDir::new().unwrap();
+        let cache_dir = TempDir::new().unwrap();
+        let planner = TestPlanner::new(work_dir.path(), cache_dir.path());
+
+        let tests_index = TestsIndex {
+            version: "1.0".to_string(),
+            generated_at: "now".to_string(),
+            python_version: "3.11".to_string(),
+            pytest_version: "8.0".to_string(),
+            tests: vec![
+                TestNode {
+                    nodeid: "test_sample.py::test_ok".to_string(),
+                    path: "test_sample.py".to_string(),
+                    line: 1,
+                    function: "test_ok".to_string(),
+                    class: None,
+                    module: "test_sample".to_string(),
+                    markers: vec![],
+                    fixtures: vec![],
+                    parametrize: None,
+                },
+                TestNode {
+                    nodeid: "other.py::test_other".to_string(),
+                    path: "other.py".to_string(),
+                    line: 1,
+                    function: "test_other".to_string(),
+                    class: None,
+                    module: "other".to_string(),
+                    markers: vec![],
+                    fixtures: vec![],
+                    parametrize: None,
+                },
+            ],
+            collection_errors: vec![],
+        };
+
+        let revdeps = ReverseDepsGraph {
+            version: "1.0".to_string(),
+            generated_at: "now".to_string(),
+            reverse_deps: HashMap::new(),
+        };
+
+        let module_map = ModuleMap {
+            version: "1.0".to_string(),
+            generated_at: "now".to_string(),
+            modules: HashMap::new(),
+            packages: vec![],
+        };
+
+        let imports_graph = ImportsGraph {
+            version: "1.0".to_string(),
+            generated_at: "now".to_string(),
+            edges: vec![],
+            dynamic_imports: vec![],
+            unresolved_imports: vec![],
+        };
+
+        let selection = planner
+            .plan_test_selection(
+                &["test_sample.py".to_string()],
+                &tests_index,
+                &revdeps,
+                &module_map,
+                &imports_graph,
+            )
+            .unwrap();
+
+        assert_eq!(selection.selected_nodeids, vec!["test_sample.py::test_ok"]);
+        assert!(!selection.should_broaden);
+    }
+}

--- a/crates/veri-core/src/python_worker.rs
+++ b/crates/veri-core/src/python_worker.rs
@@ -536,3 +536,30 @@ pub struct TestRunOptions {
     pub coverage_source_dirs: Vec<String>,
     pub coverage_omit: Vec<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn collects_and_runs_tests() {
+        let work_dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let cache_dir = work_dir.path().join(".veri").join("cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        fs::write(
+            work_dir.path().join("test_sample.py"),
+            "def test_ok():\n    assert 1 + 1 == 2\n",
+        )
+        .unwrap();
+
+        let worker = PythonWorker::new(work_dir.path(), &cache_dir);
+        let index = worker.collect_tests(&[]).expect("collect tests");
+        assert_eq!(index.tests.len(), 1);
+
+        let exit_code = worker.run_pytest_engine(&[]).expect("run tests");
+        assert_eq!(exit_code, 0);
+    }
+}

--- a/crates/veri-core/src/scheduler.rs
+++ b/crates/veri-core/src/scheduler.rs
@@ -523,4 +523,70 @@ mod tests {
         assert_eq!(batches[0].nodeids.len(), 1);
         assert_eq!(batches[0].nodeids[0], "test_example.py::test_function");
     }
+
+    #[test]
+    fn schedules_failures_first() {
+        let config = SchedulerConfig {
+            strategy: SchedulingStrategy::FailFirst,
+            worker_count: 1,
+            ..Default::default()
+        };
+        let mut scheduler = TestScheduler::new(config);
+        scheduler.timings.insert(
+            "test_ok".to_string(),
+            TestTiming {
+                nodeid: "test_ok".to_string(),
+                duration_ms: 100,
+                last_outcome: TestOutcome::Passed,
+                stability_score: 1.0,
+            },
+        );
+        scheduler.timings.insert(
+            "test_fail".to_string(),
+            TestTiming {
+                nodeid: "test_fail".to_string(),
+                duration_ms: 100,
+                last_outcome: TestOutcome::Failed,
+                stability_score: 1.0,
+            },
+        );
+        scheduler.last_failed.insert("test_fail".to_string());
+
+        let tests_index = TestsIndex {
+            version: "1.0".to_string(),
+            generated_at: "now".to_string(),
+            python_version: "3".to_string(),
+            pytest_version: "7".to_string(),
+            tests: vec![
+                TestNode {
+                    nodeid: "test_ok".to_string(),
+                    path: "test_ok.py".to_string(),
+                    line: 1,
+                    function: "test_ok".to_string(),
+                    class: None,
+                    module: "test_ok".to_string(),
+                    markers: vec![],
+                    fixtures: vec![],
+                    parametrize: None,
+                },
+                TestNode {
+                    nodeid: "test_fail".to_string(),
+                    path: "test_fail.py".to_string(),
+                    line: 1,
+                    function: "test_fail".to_string(),
+                    class: None,
+                    module: "test_fail".to_string(),
+                    markers: vec![],
+                    fixtures: vec![],
+                    parametrize: None,
+                },
+            ],
+            collection_errors: vec![],
+        };
+
+        let nodeids = vec!["test_ok".to_string(), "test_fail".to_string()];
+        let batches = scheduler.schedule_tests(&nodeids, &tests_index).unwrap();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].nodeids[0], "test_fail");
+    }
 }

--- a/crates/veri-core/src/watch.rs
+++ b/crates/veri-core/src/watch.rs
@@ -647,6 +647,7 @@ fn glob_match(pattern: &str, text: &str) -> bool {
 mod tests {
     use super::*;
     use std::time::Duration;
+    use tempfile::TempDir;
 
     #[test]
     fn test_debouncer() {
@@ -682,5 +683,21 @@ mod tests {
         assert!(!glob_match("*.py", "test.txt"));
         assert!(glob_match("test.py", "test.py"));
         assert!(!glob_match("test.py", "other.py"));
+    }
+
+    #[test]
+    fn respects_ignore_rules() {
+        let temp = TempDir::new().unwrap();
+        let work_dir = temp.path().to_path_buf();
+        let cache_dir = temp.path().join(".veri");
+        std::fs::create_dir(&cache_dir).unwrap();
+        let config = WatchConfig {
+            enable_tui: false,
+            ..Default::default()
+        };
+        let session = WatchSession::new(work_dir.clone(), cache_dir, config).unwrap();
+
+        assert!(!session.should_process_file(&work_dir.join("__pycache__").join("mod.pyc")));
+        assert!(session.should_process_file(&work_dir.join("test_example.py")));
     }
 }

--- a/crates/veri-core/src/worker_pool.rs
+++ b/crates/veri-core/src/worker_pool.rs
@@ -9,8 +9,8 @@ use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
-use std::path::{Path, PathBuf};
 use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
@@ -47,7 +47,7 @@ impl Default for WorkerPoolConfig {
             startup_timeout: Duration::from_secs(30),
             execution_timeout: Duration::from_secs(300), // 5 minutes
             heartbeat_interval: Duration::from_secs(10),
-            max_idle_time: Duration::from_secs(600),     // 10 minutes
+            max_idle_time: Duration::from_secs(600), // 10 minutes
             enable_recycling: true,
             work_dir: std::env::current_dir().unwrap_or_default(),
             cache_dir: std::env::current_dir()
@@ -186,9 +186,16 @@ pub struct BatchResult {
 
 #[derive(Debug)]
 enum WorkerEvent {
-    HelloOk { worker_id: usize },
-    HealthOk { worker_id: usize },
-    TestResults { worker_id: usize, response: WorkerResponse },
+    HelloOk {
+        worker_id: usize,
+    },
+    HealthOk {
+        worker_id: usize,
+    },
+    TestResults {
+        worker_id: usize,
+        response: WorkerResponse,
+    },
 }
 
 impl WorkerPool {
@@ -375,7 +382,10 @@ impl WorkerPool {
         // Drain worker events
         for evt in self.evt_rx.try_iter() {
             match evt {
-                WorkerEvent::TestResults { worker_id, response } => {
+                WorkerEvent::TestResults {
+                    worker_id,
+                    response,
+                } => {
                     if let WorkerResponse::TestResults {
                         batch_id,
                         exit_code,
@@ -394,7 +404,13 @@ impl WorkerPool {
                                 stderr: stderr.to_string(),
                                 duration: Duration::from_millis(*duration_ms),
                                 nodeids: ctx.batch.nodeids.clone(),
-                                per_test: if let WorkerResponse::TestResults { per_test, .. } = response { per_test.unwrap_or_default() } else { Vec::new() },
+                                per_test: if let WorkerResponse::TestResults { per_test, .. } =
+                                    response
+                                {
+                                    per_test.unwrap_or_default()
+                                } else {
+                                    Vec::new()
+                                },
                             };
                             out.push(br);
                             if let Some(w) = self.workers.get_mut(worker_id) {
@@ -640,7 +656,10 @@ impl WorkerPool {
 
         // Try repo relative to this crate (../../py_worker)
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let cand = manifest_dir.parent().and_then(|p| p.parent()).map(|p| p.join("py_worker"));
+        let cand = manifest_dir
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("py_worker"));
         if let Some(c) = cand {
             if c.exists() {
                 return Some(c);
@@ -653,7 +672,11 @@ impl WorkerPool {
         thread::spawn(move || {
             while let Ok(msg) = rx.recv() {
                 let json = match msg {
-                    WorkerMessage::ExecuteTests { batch_id, nodeids, options } => {
+                    WorkerMessage::ExecuteTests {
+                        batch_id,
+                        nodeids,
+                        options,
+                    } => {
                         let junit = options
                             .junit_xml
                             .as_ref()
@@ -708,21 +731,64 @@ impl WorkerPool {
                             let _ = evt_tx.send(WorkerEvent::HealthOk { worker_id });
                         }
                         "TestResults" => {
-                            let batch_id = val.get("batch_id").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                            let exit_code = val.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(3) as i32;
-                            let stdout_s = val.get("stdout").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                            let stderr_s = val.get("stderr").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                            let duration_ms = val.get("duration_ms").and_then(|v| v.as_i64()).unwrap_or(0) as u64;
-                            let per_test = val.get("per_test").and_then(|arr| arr.as_array()).map(|arr| {
-                                arr.iter().filter_map(|x| {
-                                    let nodeid = x.get("nodeid").and_then(|v| v.as_str())?.to_string();
-                                    let outcome = x.get("outcome").and_then(|v| v.as_str())?.to_string();
-                                    let duration_ms = x.get("duration_ms").and_then(|v| v.as_i64()).unwrap_or(0) as u64;
-                                    Some(PerTestResult { nodeid, outcome, duration_ms })
-                                }).collect::<Vec<PerTestResult>>()
+                            let batch_id = val
+                                .get("batch_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let exit_code =
+                                val.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(3) as i32;
+                            let stdout_s = val
+                                .get("stdout")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let stderr_s = val
+                                .get("stderr")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let duration_ms =
+                                val.get("duration_ms").and_then(|v| v.as_i64()).unwrap_or(0) as u64;
+                            let per_test =
+                                val.get("per_test")
+                                    .and_then(|arr| arr.as_array())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .filter_map(|x| {
+                                                let nodeid = x
+                                                    .get("nodeid")
+                                                    .and_then(|v| v.as_str())?
+                                                    .to_string();
+                                                let outcome = x
+                                                    .get("outcome")
+                                                    .and_then(|v| v.as_str())?
+                                                    .to_string();
+                                                let duration_ms = x
+                                                    .get("duration_ms")
+                                                    .and_then(|v| v.as_i64())
+                                                    .unwrap_or(0)
+                                                    as u64;
+                                                Some(PerTestResult {
+                                                    nodeid,
+                                                    outcome,
+                                                    duration_ms,
+                                                })
+                                            })
+                                            .collect::<Vec<PerTestResult>>()
+                                    });
+                            let resp = WorkerResponse::TestResults {
+                                batch_id,
+                                exit_code,
+                                stdout: stdout_s,
+                                stderr: stderr_s,
+                                duration_ms,
+                                per_test,
+                            };
+                            let _ = evt_tx.send(WorkerEvent::TestResults {
+                                worker_id,
+                                response: resp,
                             });
-                            let resp = WorkerResponse::TestResults { batch_id, exit_code, stdout: stdout_s, stderr: stderr_s, duration_ms, per_test };
-                            let _ = evt_tx.send(WorkerEvent::TestResults { worker_id, response: resp });
                         }
                         "Error" => warn!("Worker {} error: {}", worker_id, line),
                         _ => debug!("Worker {} msg: {}", worker_id, line),
@@ -943,6 +1009,8 @@ pub struct WorkerPoolStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn test_worker_pool_creation() {
@@ -968,5 +1036,41 @@ mod tests {
         assert!(config.startup_timeout > Duration::ZERO);
         assert!(config.execution_timeout > Duration::ZERO);
         assert!(config.enable_recycling);
+    }
+
+    #[test]
+    fn executes_test_batch() {
+        let work_dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        let cache_dir = TempDir::new_in(env!("CARGO_MANIFEST_DIR")).unwrap();
+        fs::write(
+            work_dir.path().join("test_sample.py"),
+            "def test_ok():\n    assert 1 == 1\n",
+        )
+        .unwrap();
+
+        let config = WorkerPoolConfig {
+            worker_count: 1,
+            work_dir: work_dir.path().to_path_buf(),
+            cache_dir: cache_dir.path().to_path_buf(),
+            ..Default::default()
+        };
+        let mut pool = WorkerPool::new(config);
+        pool.start().expect("start pool");
+
+        let batch = TestBatch {
+            worker_id: 0,
+            nodeids: vec!["test_sample.py::test_ok".to_string()],
+            estimated_duration_ms: 0,
+            contains_last_failed: false,
+        };
+        pool.submit_batch("batch1".to_string(), batch, TestRunOptions::default())
+            .expect("submit batch");
+
+        let results = pool
+            .wait_for_completion(Some(Duration::from_secs(30)))
+            .expect("wait completion");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].exit_code, 0);
+        pool.shutdown().unwrap();
     }
 }

--- a/crates/veri-core/src/worker_pool.rs
+++ b/crates/veri-core/src/worker_pool.rs
@@ -718,7 +718,7 @@ impl WorkerPool {
     ) {
         thread::spawn(move || {
             let reader = BufReader::new(stdout);
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 if let Ok(val) = serde_json::from_str::<Value>(&line) {
                     let t = val.get("t").and_then(|v| v.as_str()).unwrap_or("");
                     match t {
@@ -807,7 +807,7 @@ impl WorkerPool {
     ) {
         thread::spawn(move || {
             let reader = BufReader::new(stderr);
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 warn!("Worker {} stderr: {}", worker_id, line);
             }
         });

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,0 +1,81 @@
+# Comprehensive Functional Test Plan for `veri`
+
+## Goals
+- Exercise real end-to-end behaviour across the Rust core, Python worker and CLI.
+- Validate public JSON schemas and stable contracts.
+- Cover concurrency, scheduling and file-system interactions without mocks.
+- Maintain fast feedback by reusing temporary directories and small sample test projects.
+
+## Current Coverage & Gaps
+- CLI tests only verify flag parsing; they never spawn real commands or workers.
+- Rust modules such as planner and import graph builder lack any tests.
+- Worker pool, scheduler, cache and watch modules have only small unit tests and no integration runs.
+- Python worker tests already exercise collection on temporary projects and can serve as a pattern for functional tests across the repo.
+
+## Proposed Tests by Component
+
+### 1. Python Worker (`crates/veri-core/src/python_worker.rs`)
+- **Collect & Run Tests:** Run `collect_tests` and `run_tests` against a temporary project with multiple files, markers and fixtures to ensure subprocess invocation, exit codes and produced indexes.
+- **Coverage & Options:** Execute runs with coverage flags and junit/xml options, verifying files are written to cache.
+- **Error Handling:** Intentionally introduce failing tests, syntax errors, or missing worker script to confirm error paths return meaningful `anyhow!` messages.
+
+### 2. Import Graph Builder (`crates/veri-core/src/import_graph.rs`)
+- Build a tiny module graph with dynamic imports and validate that edges, dynamic imports and unresolved imports are captured.
+- Cross-validate the generated graph using the Python `VeriASTParser` to guarantee parity.
+
+### 3. Planner (`crates/veri-core/src/planner.rs`)
+- Create a miniature project with known dependencies; modify source files and ensure `plan_test_selection` chooses the correct tests and broaden behaviour.
+- Test rules for test files, `conftest.py` scopes and dynamic import safety.
+
+### 4. Scheduler (`crates/veri-core/src/scheduler.rs`)
+- **Deterministic Scheduling:** Provide historical timings and verify bin-packing assigns tests to workers based on priority, last-failed flags and estimated durations.
+- **Strategy Variants:** Run `Fastest`, `FailFirst` and `Balanced` strategies and assert ordering of batches.
+- **Property Testing:** Use `proptest` to generate random timing data and ensure total estimated duration per worker never exceeds `max_batch_duration_ms`.
+
+### 5. Worker Pool (`crates/veri-core/src/worker_pool.rs`)
+- Spin up real Python workers in parallel; submit batches and verify results, stdout/stderr and heartbeat events.
+- Test recycling by idling workers longer than `max_idle_time` and ensuring processes restart.
+- Simulate worker crash by killing a child process and ensure pool marks it failed and reschedules work.
+
+### 6. Watch Mode (`crates/veri-core/src/watch.rs`)
+- Create temporary directories with nested `__pycache__` and ignored patterns; verify that watch sessions skip ignored paths and trigger rebuild after debounce window.
+- Test integration with `TestPlanner` and `PythonWorker` by modifying a source file and asserting only impacted tests run.
+
+### 7. Cache (`crates/veri-core/src/cache.rs`)
+- Build real cache keys by writing `uv.lock`, multiple `conftest.py` files and pytest plugins; ensure `compute_hash` changes when any component changes.
+- Verify `find_conftest_files` skips ignored directories and handles large directory trees.
+
+### 8. Event Stream & Telemetry (`crates/veri-core/src/event_stream.rs`, `telemetry.rs`)
+- Produce a full test run, write JSONL events and validate against `schemas/event.jsonl.json` for every event type.
+- Confirm `telemetry` counters increment on success/failure paths.
+
+### 9. CLI Integration (`crates/veri-cli`)
+- Use `assert_cmd` to run the compiled binary against the sample project:
+  - `veri collect` – ensures indexes are produced.
+  - `veri run` – executes tests, checks exit codes and output.
+  - `veri watch` – start watcher, touch files and assert run triggers.
+- Validate split/shard subcommands by comparing produced shard manifests.
+
+### 10. Schema Validation (`schemas/`)
+- Use Rust `jsonschema` crate or Python `jsonschema` to validate `tests.index.json`, `markers.index.json`, `imports.graph.json`, etc., ensuring cross-language compatibility.
+- Add regression tests that load past schema versions to maintain backward compatibility.
+
+### 11. Cross-Language & End-to-End
+- Combine components: run CLI to collect, plan, schedule and execute tests while streaming events; then load outputs and assert that scheduler and planner decisions match expectations.
+- Use the `examples/` directory as canonical end-to-end scenarios.
+
+### 12. Performance & Stress
+- Measure scheduler and worker pool throughput with `criterion` or timed integration tests.
+- Run high-parallelism tests to detect race conditions or file-system watcher saturation.
+
+### 13. Cross-Platform & Tooling
+- Extend CI matrix to run on Linux, macOS and Windows to catch watcher or path issues.
+- Use `cargo nextest` for Rust tests and `uv run pytest -v` for Python tests to ensure consistent environments.
+
+## Continuous Integration Workflow
+1. `cargo test --workspace` – Rust unit and integration tests.
+2. `uv run pytest -v` inside `py_worker/` – Python tests.
+3. `just check` – combined `fmt`, `lint`, and type checks.
+4. Add a full end-to-end job running the CLI against a sample project to verify schemas and event streams.
+
+By emphasising real subprocesses, file systems and JSON schemas, this plan drives the project toward robust functional coverage with minimal reliance on mocks.


### PR DESCRIPTION
## Summary
- exercise Python worker end-to-end via pytest engine
- validate planner selection, scheduler ordering, worker pool execution, watch ignore rules, and CLI collect
- add assert_cmd for CLI integration tests

## Testing
- `cargo test --workspace`
- `cd py_worker && uv run pytest -v`
- `make check` *(fails: clippy `lines_filter_map_ok` in `worker_pool.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68b468a2f96483339430ab655fda4753